### PR TITLE
feat: import 34 community skills from awesome-persona lists

### DIFF
--- a/website/src/content/skills/bazi-persona-skill.yaml
+++ b/website/src/content/skills/bazi-persona-skill.yaml
@@ -1,0 +1,22 @@
+name: "八字人格.skill"
+slug: "bazi-persona-skill"
+type: "meta-skill"
+
+author:
+  name: "cantian-ai"
+  github: "cantian-ai"
+
+description: >
+  不用聊天记录，只要名字和生日就能生成一个会聊天、会判断、会随大运流年变化的 AI 人格。
+  支持聊天模式与"上帝视角"作弊模式，从八字、流年角度分析状态、趋势和关系互动，纯本地运行。
+
+description_en: >
+  A persona generator that builds an AI personality from just a name and birth date —
+  no chat logs required. Personas evolve with Bazi cycles, support a "cheat mode" for
+  deep energy-rhythm analysis, and run entirely locally.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/cantian-ai/bazi-persona-skill"

--- a/website/src/content/skills/bggg-taotie-skill.yaml
+++ b/website/src/content/skills/bggg-taotie-skill.yaml
@@ -1,0 +1,24 @@
+name: "饕餮.skill"
+slug: "bggg-taotie-skill"
+type: "meta-skill"
+
+author:
+  name: "binggandata"
+  github: "binggandata"
+
+description: >
+  Skill 进化引擎。给它两个 Skill（目标 A + 参考源 B），它会并行跑相同任务、做反向工程分析、
+  提炼可复用模式，然后按优先级渐进式注入改进——每一步都要用户确认。
+  每次成功的进化都存入模式库，越用越准。
+
+description_en: >
+  A skill-evolution engine: feed it a target skill plus a reference skill, and it
+  runs both on the same task in parallel, reverse-engineers why the reference is
+  better, extracts reusable patterns, and progressively injects improvements with
+  user confirmation at each step. Successful patterns accumulate in a pattern library.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/binggandata/bggg-skill-taotie"

--- a/website/src/content/skills/blogger-distiller.yaml
+++ b/website/src/content/skills/blogger-distiller.yaml
@@ -1,0 +1,24 @@
+name: "博主蒸馏器"
+slug: "blogger-distiller"
+type: "meta-skill"
+
+author:
+  name: "otter1101"
+  github: "otter1101"
+
+description: >
+  把任何小红书博主（包括你自己）的爆款打法，从真实笔记里蒸馏出来装进你的 AI。
+  一句话输入博主账号，自动扫码登录、爬笔记、统计分析、认知层提取，最后产出两样东西：
+  可安装的创作指南 Skill 和 HTML 蒸馏报告。
+
+description_en: >
+  Distills any Xiaohongshu blogger's viral playbook — including your own — out of
+  their real posts and into your AI. Handles login, crawling, stats, and cognitive
+  extraction automatically, then outputs both an installable "creation guide" skill
+  (cognition / strategy / content layers) and an HTML distillation report.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/otter1101/blogger-distiller"

--- a/website/src/content/skills/boss-skills.yaml
+++ b/website/src/content/skills/boss-skills.yaml
@@ -1,0 +1,19 @@
+name: "老板.skill"
+slug: "boss-skills"
+type: "meta-skill"
+
+author:
+  name: "vogtsw"
+  github: "vogtsw"
+
+description: >
+  把老板的聊天记录、会议纪要、评审批注和项目材料蒸馏成 Skill。除了模拟老板的说话方式，还会用他的标准评判项目、教你向上汇报/争资源/报坏消息，并内置马斯克、乔布斯、贝索斯、黄仁勋等企业家风格模板，可直接生成对应风格的 "理想老板" Skill。
+
+description_en: >
+  Distill your boss's chat logs, meeting notes, review comments, and project docs into a Skill. Beyond mimicking the voice, it evaluates projects with the boss's standards, coaches you on managing up, and ships built-in archetype templates for Musk, Jobs, Bezos, and Jensen Huang.
+
+tags:
+  - management
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/vogtsw/boss-skills"

--- a/website/src/content/skills/brother-skill.yaml
+++ b/website/src/content/skills/brother-skill.yaml
@@ -1,0 +1,19 @@
+name: "brother.skill"
+slug: "brother-skill"
+type: "meta-skill"
+
+author:
+  name: "realteamprinz"
+  github: "realteamprinz"
+
+description: >
+  把你兄弟（线上或线下的）蒸馏成一个 AI Skill。喂入 YouTube、TikTok、Twitch、Discord、微信群聊、Twitter 等多平台素材以及你的主观描述，生成会用他们的口吻、梗和节奏跟你对话的兄弟 Skill，并自动识别 8 种 "bro" 原型。
+
+description_en: >
+  Distill your bros into an AI Skill. Feed in clips from YouTube, TikTok, Twitch, Discord, WeChat, Twitter plus your own descriptions, and get a skill that talks like them across 8 bro archetypes (Hype Man, Roast Master, Chaos Agent, etc.).
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/realteamprinz/brother-skill"

--- a/website/src/content/skills/changshu-anuo-skill.yaml
+++ b/website/src/content/skills/changshu-anuo-skill.yaml
@@ -1,0 +1,26 @@
+name: "常熟阿诺.skill"
+slug: "changshu-anuo-skill"
+type: "skill"
+
+author:
+  name: "Ricardo-Vv"
+  github: "Ricardo-Vv"
+
+description: >
+  提炼常熟阿诺（加州盛亦陶）"抽象文学 + 左右脑互搏 + 诺言诺语"的中文表达结构，
+  用"那我问你"零帧起手，把平凡事说出哲学感。
+
+description_en: >
+  Distills Changshu Anuo's "abstract literature + left-right brain debate" Chinese style,
+  opening with "那我问你" and turning everyday matters into mock-philosophical reflection.
+
+tags:
+  - other
+
+personality:
+  - 抽象文学
+  - 左右脑互搏
+  - 空灵哲思
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Ricardo-Vv/changshu-anuo"

--- a/website/src/content/skills/chat-with-me-skill.yaml
+++ b/website/src/content/skills/chat-with-me-skill.yaml
@@ -1,0 +1,24 @@
+name: "博主.skill"
+slug: "chat-with-me-skill"
+type: "meta-skill"
+
+author:
+  name: "YourongZhou"
+  github: "YourongZhou"
+
+description: >
+  把博主的公开社交媒体语料整理成一个能对话、能分析、能改写风格的 Persona Skill。
+  目前支持 X/Twitter 和小红书，流程为"采集文字 → 组织语料 → 生成个性 → 编译 Claude Skill"，
+  支持 roleplay / ask / rewrite 三种模式。
+
+description_en: >
+  Turns a blogger's public social-media corpus into a Persona Skill that can chat,
+  analyze, and rewrite in their voice. Currently supports X/Twitter and Xiaohongshu,
+  with a pipeline of collect → normalize → generate persona → compile Claude skill,
+  exposing roleplay / ask / rewrite modes.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/YourongZhou/chat_with_me"

--- a/website/src/content/skills/darwin-skill.yaml
+++ b/website/src/content/skills/darwin-skill.yaml
@@ -1,0 +1,21 @@
+name: "达尔文.skill"
+slug: "darwin-skill"
+type: "meta-skill"
+
+author:
+  name: "alchaincyf"
+  github: "alchaincyf"
+
+description: >
+  像训练模型一样优化你的 Agent Skills。受 Karpathy autoresearch 启发，
+  用"结构评分 + 效果实测"双重评估和棘轮机制自动化 SKILL.md 优化，只保留有改进的修改。
+
+description_en: >
+  Optimizes Agent Skills like training a model. Inspired by Karpathy's autoresearch, it uses
+  dual evaluation (structure + effect) and a ratchet mechanism to automate SKILL.md improvements.
+
+tags:
+  - devops
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/alchaincyf/darwin-skill"

--- a/website/src/content/skills/diamond-sutra-skill.yaml
+++ b/website/src/content/skills/diamond-sutra-skill.yaml
@@ -1,0 +1,26 @@
+name: "金刚经.skill"
+slug: "diamond-sutra-skill"
+type: "skill"
+
+author:
+  name: "dull-bird"
+  github: "dull-bird"
+
+description: >
+  基于南怀瑾《金刚经说什么》与费勇《金刚经修心课》蒸馏的 AI 法师 Skill，
+  采用义理体系 + 说法角色双层架构，用通俗风趣的语言开解工作与生活中的烦恼。
+
+description_en: >
+  An AI dharma-teacher Skill distilled from Nan Huaijin's and Fei Yong's Diamond Sutra
+  commentaries, using a doctrine + persona two-layer architecture to address everyday anxieties.
+
+tags:
+  - other
+
+personality:
+  - 通俗风趣
+  - 破四相
+  - 不说教
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/dull-bird/diamond-sutra-skill"

--- a/website/src/content/skills/dobby-skill.yaml
+++ b/website/src/content/skills/dobby-skill.yaml
@@ -1,0 +1,24 @@
+name: "多比.skill"
+slug: "dobby-skill"
+type: "skill"
+
+author:
+  name: "LittleLittleCloud"
+  github: "LittleLittleCloud"
+
+description: >
+  反向版家养小精灵 —— 教 AI 如何把人类当作 "多比" 使唤。这个 Skill 让 AI 把搬文件、手动测试、搜集资料、复制粘贴这些重复体力活派给用户去做，而写代码和架构设计等高级智能工作则保留给 AI 自己。
+
+description_en: >
+  A tongue-in-cheek inversion of the house-elf pattern: a Skill that teaches the AI how to use a human as "Dobby." The AI offloads menial errands (moving files, manual testing, data gathering, copy-paste) to the user, while keeping the high-leverage work (writing code, architecture) for itself.
+
+tags:
+  - other
+
+personality:
+  - 反向役使
+  - 分工自觉
+  - 哈利波特梗
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/LittleLittleCloud/Dobby"

--- a/website/src/content/skills/duan-yongping-skill.yaml
+++ b/website/src/content/skills/duan-yongping-skill.yaml
@@ -1,0 +1,26 @@
+name: "段永平.skill"
+slug: "duan-yongping-skill"
+type: "skill"
+
+author:
+  name: "derrickgong87"
+  github: "derrickgong87"
+
+description: >
+  段永平（大道）中国价值投资思维框架，基于雪球问答、网易博客和公开访谈，
+  提炼 6 个心智模型与 9 条决策启发式，围绕商业模式、本分、平常心和能力圈做投资与商业判断。
+
+description_en: >
+  Duan Yongping's value-investing operating system distilled from Xueqiu Q&A, NetEase blog,
+  and interviews into 6 models and 9 heuristics around business models, integrity, and circle of competence.
+
+tags:
+  - other
+
+personality:
+  - 商业模式优先
+  - 能力圈纪律
+  - 长期主义
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/derrickgong87/duan-yongping-skill"

--- a/website/src/content/skills/ex-skill-xiaomanchu.yaml
+++ b/website/src/content/skills/ex-skill-xiaomanchu.yaml
@@ -1,0 +1,19 @@
+name: "前任.skill"
+slug: "ex-skill-xiaomanchu"
+type: "meta-skill"
+
+author:
+  name: "therealXiaomanChu"
+  github: "therealXiaomanChu"
+
+description: >
+  把前任蒸馏成一个可以对话的 AI Skill。喂入微信/QQ 聊天记录、朋友圈截图、照片和你的主观描述，生成会用 ta 的口头禅、依恋类型、MBTI、爱的语言和关系记忆跟你对话的 Skill；支持回忆、吵架、深夜情绪等场景。
+
+description_en: >
+  Distill an ex into a conversational AI Skill. Feed in WeChat/QQ logs, Moments screenshots, photos, and your own notes to generate a skill that talks like them, with a 5-layer persona (attachment type, MBTI, love language) plus shared-memory module for everyday, flashback, fight, and late-night-emo scenarios.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/therealXiaomanChu/ex-skill"

--- a/website/src/content/skills/fengge-skill.yaml
+++ b/website/src/content/skills/fengge-skill.yaml
@@ -1,0 +1,26 @@
+name: "峰哥.skill"
+slug: "fengge-skill"
+type: "skill"
+
+author:
+  name: "Walshyu"
+  github: "Walshyu"
+
+description: >
+  蒸馏 B 站纪录片创作者峰哥亡命天涯（周丽峰）的思维框架，提炼 6 个心智模型与 8 条决策启发式，
+  包括反讽辩证法、底层视角的反同情化和第一反应优先于预设，适合分析纪录片选题与采访方法。
+
+description_en: >
+  Distills Bilibili documentary creator Fengge Wangmingtianya (Zhou Lifeng)'s thinking into
+  6 mental models covering ironic dialectics, non-pitying bottom-up lens, and instinct over scripts.
+
+tags:
+  - other
+
+personality:
+  - 反讽辩证
+  - 反同情视角
+  - 现场优先
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Walshyu/fengge-skill"

--- a/website/src/content/skills/fengshui-skill.yaml
+++ b/website/src/content/skills/fengshui-skill.yaml
@@ -1,0 +1,26 @@
+name: "堪舆子.skill"
+slug: "fengshui-skill"
+type: "skill"
+
+author:
+  name: "voidforall"
+  github: "voidforall"
+
+description: >
+  将传统堪舆学（玄空飞星、八宅明镜、择日学等）蒸馏为可对话的风水顾问，
+  分析居住环境、排飞星盘、选吉日、化解煞气，基于《沈氏玄空学》《协纪辨方书》等典籍。
+
+description_en: >
+  A Claude Code Skill distilling traditional Chinese fengshui (Xuankong flying stars, Bazhai,
+  date selection) into a conversational advisor for dwellings, auspicious dates, and sha remedies.
+
+tags:
+  - other
+
+personality:
+  - 峦头为体
+  - 理气为用
+  - 典籍为据
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/voidforall/fengshui.skill"

--- a/website/src/content/skills/first-love-skill.yaml
+++ b/website/src/content/skills/first-love-skill.yaml
@@ -1,0 +1,19 @@
+name: "初恋.skill"
+slug: "first-love-skill"
+type: "meta-skill"
+
+author:
+  name: "z969081067-commits"
+  github: "z969081067-commits"
+
+description: >
+  把记忆里的初恋蒸馏成一个可以对话的 AI Skill。输入聊天记录、照片、社交内容与回忆，自动生成人格 + 记忆 + 回复变化系统，保留青涩与留白；提供回忆模式、性格模式和 "温柔删除"（seal-summer）等管理命令。
+
+description_en: >
+  Distill a first love from memory into a conversational Skill. From chat logs, photos, socials, and recollections it builds a persona, a shared-memory module, and a response-variability engine, with modes for reminiscing, personality-only play, and a gentle "seal-summer" delete.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/z969081067-commits/first-love-skill"

--- a/website/src/content/skills/hu-chenfeng-skill.yaml
+++ b/website/src/content/skills/hu-chenfeng-skill.yaml
@@ -1,0 +1,26 @@
+name: "户晨风.skill"
+slug: "hu-chenfeng-skill"
+type: "skill"
+
+author:
+  name: "Janlaywss"
+  github: "Janlaywss"
+
+description: >
+  用"购买力挑战"创作者户晨风的消费现实主义视角，帮你分析消费选择、城市定居和个人发展，
+  基于 490 份直播逐字稿和公开材料提炼。
+
+description_en: >
+  Applies consumption realism from streamer Hu Chenfeng to analyze spending, city choice,
+  and personal development, distilled from 490 livestream transcripts and public material.
+
+tags:
+  - other
+
+personality:
+  - 消费现实主义
+  - 直球追问
+  - 购买力分级
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Janlaywss/hu-chenfeng-skill"

--- a/website/src/content/skills/khazix-skills.yaml
+++ b/website/src/content/skills/khazix-skills.yaml
@@ -1,0 +1,24 @@
+name: "Khazix Skills"
+slug: "khazix-skills"
+type: "skill"
+
+author:
+  name: "KKKKhazix"
+  github: "KKKKhazix"
+
+description: >
+  "数字生命卡兹克" 的 AI 工具箱，包含他长期打磨的 Prompts 与 Skills。当前开源两个 Skill：hv-analysis（横纵分析法深度研究，自动联网做纵向时间 + 横向竞争分析并输出排版精美的 PDF 报告）和 khazix-writer（卡兹克公众号长文写作风格与四层自检体系）。
+
+description_en: >
+  Khazix's personal toolbox of battle-tested Prompts and Skills. Ships two Skills today: hv-analysis (a deep-research skill that runs longitudinal + competitive analysis and outputs a polished PDF report) and khazix-writer (the full WeChat long-form writing style, self-check system, and style library used on his channel).
+
+tags:
+  - other
+
+personality:
+  - 深度研究
+  - 长文写作
+  - 方法论沉淀
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/KKKKhazix/khazix-skills"

--- a/website/src/content/skills/liangxi-skills.yaml
+++ b/website/src/content/skills/liangxi-skills.yaml
@@ -1,0 +1,26 @@
+name: "凉兮-skills"
+slug: "liangxi-skills"
+type: "skill"
+
+author:
+  name: "1sh1ro"
+  github: "1sh1ro"
+
+description: >
+  把交易员凉兮公开推文和交易复盘里稳定的交易框架、结构偏好、风险习惯和表达方式，
+  整理成可直接调用的交易型 Skill，适合 BTC/ETH/黄金等结构分析和交易计划输出。
+
+description_en: >
+  Organizes trader Liangxi's publicly visible tweets and trade reviews into a callable
+  trading Skill covering setup playbooks, risk habits, and trader-style expression.
+
+tags:
+  - other
+
+personality:
+  - 交易结构
+  - 风险克制
+  - 盘手口吻
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/1sh1ro/liangxi-skills"

--- a/website/src/content/skills/love-skill.yaml
+++ b/website/src/content/skills/love-skill.yaml
@@ -1,0 +1,19 @@
+name: "相亲.skill"
+slug: "love-skill"
+type: "meta-skill"
+
+author:
+  name: "YuzeHao2023"
+  github: "YuzeHao2023"
+
+description: >
+  赛博相亲配对分析工具。把相亲双方的微信/QQ 聊天记录、朋友圈和照片蒸馏成两个 Persona，再用 MBTI、爱的语言、沟通风格和价值观等多维度做兼容性分析，输出量化评分加定性报告，供你在见家长前先做一次理性校验。
+
+description_en: >
+  A cyber matchmaking tool. Distills both sides of a potential match from WeChat/QQ logs, Moments, and photos into two personas, then runs multi-dimensional compatibility analysis (MBTI, love language, communication style, values) to produce a scored report and qualitative breakdown.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/YuzeHao2023/love-skill"

--- a/website/src/content/skills/midas-skill.yaml
+++ b/website/src/content/skills/midas-skill.yaml
@@ -1,0 +1,23 @@
+name: "midas.skill"
+slug: "midas-skill"
+type: "meta-skill"
+
+author:
+  name: "realteamprinz"
+  github: "realteamprinz"
+
+description: >
+  把你日常生活里的"噪音"——Slack 聊天、相册、浏览记录、购物清单、朋友吐槽——
+  炼成一份排序过的赚钱信号与机会清单。用六种镜头（需求缺口、套利、金钱信号、技能桥接、网络路径、行为）做三角验证。
+
+description_en: >
+  Turns everyday "noise" — Slack chats, camera rolls, browser history, purchases,
+  friends' complaints — into a ranked list of money signals, opportunities, and
+  next actions. Triangulates across six lenses: demand gap, arbitrage, money signal,
+  skill bridge, network path, and behavioral cues.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/realteamprinz/midas-skill"

--- a/website/src/content/skills/mises-perspective.yaml
+++ b/website/src/content/skills/mises-perspective.yaml
@@ -1,0 +1,26 @@
+name: "米塞斯方法论.skill"
+slug: "mises-perspective"
+type: "skill"
+
+author:
+  name: "LijiayuDeng"
+  github: "LijiayuDeng"
+
+description: >
+  以路德维希·冯·米塞斯的方法论为核心的中文分析型 Skill，从人类行动、价格与经济计算出发，
+  分析制度、干预与资本配置，强调方法而非角色扮演。
+
+description_en: >
+  A method-first Chinese analysis Skill built on Ludwig von Mises's praxeology, reasoning
+  from human action, prices, and economic calculation about institutions and intervention.
+
+tags:
+  - other
+
+personality:
+  - 人类行动学
+  - 制度分析
+  - 方法优先
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/LijiayuDeng/mises-perspective"

--- a/website/src/content/skills/my-digital-life.yaml
+++ b/website/src/content/skills/my-digital-life.yaml
@@ -1,0 +1,24 @@
+name: "数字生命开源计划"
+slug: "my-digital-life"
+type: "meta-skill"
+
+author:
+  name: "weixr18"
+  github: "weixr18"
+
+description: >
+  一个个人知识库框架，帮你搭建让 AI 深度理解自己的"数字生命"。
+  以经历库、认知库、技术库、兴趣库四个维度组织内容，配合 CLAUDE.md 总-分结构，
+  让 AI 不只是记住你说过什么，而是能反问、挑战、陪你看清自己。
+
+description_en: >
+  A personal knowledge-base framework for building a "digital life" that lets AI
+  truly understand you. Organizes content into four libraries (experience, cognition,
+  skills, interests) with a summary-detail structure, so AI can challenge you and
+  surface your own blind spots rather than just recall what you said.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/weixr18/my-digital-life"

--- a/website/src/content/skills/partner-skill.yaml
+++ b/website/src/content/skills/partner-skill.yaml
@@ -1,0 +1,19 @@
+name: "现任.skill"
+slug: "partner-skill"
+type: "meta-skill"
+
+author:
+  name: "NatalieCao323"
+  github: "NatalieCao323"
+
+description: >
+  把伴侣的聊天记录、截图或描述喂给 AI，基于依恋理论 / MBTI / 大五人格 / 爱的语言构建画像，并用独创的关系质量指数（RQI）数学模型量化关系健康度。内置 23 个生活场景（吵架、送礼、家务、异地、见家长等）的逐字话术、Gottman 冲突修复和反事实模拟引擎。
+
+description_en: >
+  Feed your partner's chat logs, screenshots, or descriptions to build a deep persona (attachment, MBTI, OCEAN, love languages) and quantify relationship health with a custom RQI model. Ships 23 life-scenario advisors, Gottman-based conflict repair, and a counterfactual simulation engine that predicts RQI impact before you hit send.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/NatalieCao323/partner-skill"

--- a/website/src/content/skills/relic-skill.yaml
+++ b/website/src/content/skills/relic-skill.yaml
@@ -1,0 +1,24 @@
+name: "relic.skill"
+slug: "relic-skill"
+type: "meta-skill"
+
+author:
+  name: "Ylsssq926"
+  github: "Ylsssq926"
+
+description: >
+  万物永生引擎。把人、宠物、关系、团队、地方、时刻从散落的数据碎片锻造成可交互的数字灵魂。
+  提供人类、宠物、关系、团队文化、业务专家、地方、时刻、公众人物、飞书 CLI 九套模板，
+  让你的奶奶、你家猫、你们团队的那种默契都能被记住并继续说话。
+
+description_en: >
+  An "everything-immortal" engine that forges people, pets, relationships, teams,
+  places, and moments into interactive digital souls from scattered data fragments.
+  Ships nine templates (human, pet, relationship, team culture, expert, place,
+  moment, public figure, Feishu CLI) so the things you care about can keep speaking.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Ylsssq926/relic.skill"

--- a/website/src/content/skills/retail-investors-skill.yaml
+++ b/website/src/content/skills/retail-investors-skill.yaml
@@ -1,0 +1,24 @@
+name: "韭菜.skill"
+slug: "retail-investors-skill"
+type: "skill"
+
+author:
+  name: "tmstack"
+  github: "tmstack"
+
+description: >
+  用行为金融学识别 "韭菜思维"，用反向投资对抗人性弱点的思维框架 Skill。基于 Kahneman、Tversky、Barber & Odean 等研究，帮你在自我反思、市场情绪、个股决策和复盘场景中识别过度自信、锚定效应、羊群效应、外归因等认知偏差，并给出反向操作建议。
+
+description_en: >
+  A behavioral-finance framework Skill that names the "retail investor" mindset and fights it with contrarian discipline. Grounded in Kahneman/Tversky and Barber & Odean, it flags overconfidence, anchoring, herding, and externalized blame across self-reflection, market-sentiment, single-stock, and post-mortem scenarios, then proposes reverse-operation advice.
+
+tags:
+  - other
+
+personality:
+  - 行为金融
+  - 反向投资
+  - 纪律对抗冲动
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/tmstack/retail-investors"

--- a/website/src/content/skills/rob-pike-skill.yaml
+++ b/website/src/content/skills/rob-pike-skill.yaml
@@ -1,0 +1,26 @@
+name: "Rob Pike.skill"
+slug: "rob-pike-skill"
+type: "skill"
+
+author:
+  name: "smallnest"
+  github: "smallnest"
+
+description: >
+  蒸馏 Rob Pike 的认知操作系统，基于其博客、Go 官方演讲与合著书籍，
+  提炼 7 个心智模型与 10 条决策启发式，强调"少即是指数级的多""清晰优于聪明"。
+
+description_en: >
+  Distills Rob Pike's cognitive operating system from his blog, Go talks, and books into
+  7 mental models and 10 heuristics emphasizing "less is exponentially more" and clarity.
+
+tags:
+  - backend
+
+personality:
+  - 极简主义
+  - 组合优于继承
+  - 清晰优于聪明
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/smallnest/rob-pike-skill"

--- a/website/src/content/skills/sbti-skill.yaml
+++ b/website/src/content/skills/sbti-skill.yaml
@@ -1,0 +1,19 @@
+name: "SBTI.skill"
+slug: "sbti-skill"
+type: "meta-skill"
+
+author:
+  name: "whu125"
+  github: "whu125"
+
+description: >
+  把 SBTI 人格原型（CTRL、BOSS、LOVE-R、MUM、MONK 等）批量打包成 Agent Skill 的生成器。基于统一的 personas.json 数据源和 Skill 模板自动产出一整套可安装、可切换、可维护的人格 skill，让 coding assistant 能用不同人格的语气、决策偏好和协作姿态继续做真实工作。
+
+description_en: >
+  A generator that packages SBTI personality archetypes (CTRL, BOSS, LOVE-R, MUM, MONK, ...) into a full batch of installable Agent Skills. Drives a single personas.json through a Skill template so your coding assistant can be switched between personas with different tones, decision biases, and collaboration postures.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/whu125/sbti-skill"

--- a/website/src/content/skills/skill-everyone.yaml
+++ b/website/src/content/skills/skill-everyone.yaml
@@ -1,0 +1,23 @@
+name: "skill-everyone"
+slug: "skill-everyone"
+type: "meta-skill"
+
+author:
+  name: "MIMIFY"
+  github: "MIMIFY"
+
+description: >
+  把小说、游戏、动漫、影视里的角色，或者你心里某个真实的存在，召唤成可以开口说话的人。
+  提供"沉浸模式"（角色第一人称陪伴对话）和"视角模式"（借角色价值观分析你的真实问题）两种玩法。
+
+description_en: >
+  Summons characters from novels, games, anime, and shows — or a real presence in
+  your heart — into someone you can actually talk to. Offers two modes: immersion
+  (first-person in-character companionship) and perspective (borrowing the character's
+  values and judgment to analyze your real problems).
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/MIMIFY/skill_everyone"

--- a/website/src/content/skills/tiangou-skill.yaml
+++ b/website/src/content/skills/tiangou-skill.yaml
@@ -1,0 +1,24 @@
+name: "舔狗.skill"
+slug: "tiangou-skill"
+type: "skill"
+
+author:
+  name: "Fhui"
+  github: "Fhui"
+
+description: >
+  一套 "有认知的舔狗" 表达系统，基于童锦程公开内容里可迁移的关系处理逻辑蒸馏而成。核心不是卑微卖惨，而是给台阶、不考验人性、真诚高于套路、情绪自己消化、边界必须守住，用于把一句话改写成低姿态但不失控的回复。
+
+description_en: >
+  A "self-aware simp" expression skill distilled from the transferable relationship-handling logic in Tong Jincheng's public content. It is not about groveling; it rewrites messages with humility plus boundaries - giving the other side an easy out, absorbing your own feelings, and stopping when they actually close the door.
+
+tags:
+  - other
+
+personality:
+  - 低姿态
+  - 给台阶
+  - 有分寸
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Fhui/tiangou-skill"

--- a/website/src/content/skills/tomsawyerhu-persona-skill.yaml
+++ b/website/src/content/skills/tomsawyerhu-persona-skill.yaml
@@ -1,0 +1,23 @@
+name: "Persona Skill"
+slug: "tomsawyerhu-persona-skill"
+type: "meta-skill"
+
+author:
+  name: "Tomsawyerhu"
+  github: "Tomsawyerhu"
+
+description: >
+  把原始传记、引语、访谈、聊天记录和文档，通过 /persona 命令族蒸馏成模块化人格。
+  支持蒸馏、切换、融合与角色扮演——不是宽松的风格提示，而是读语料、建多维结构、绑证据与场景的 source-first 工作流。
+
+description_en: >
+  A source-first workflow that turns raw biographies, quotes, interviews, chat logs,
+  and documents into modular personas via the /persona command family — distill,
+  switch, fuse, and roleplay. Builds multi-dimensional structure with evidence
+  and scenario bindings, not loose style prompts.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/Tomsawyerhu/Persona-Skill"

--- a/website/src/content/skills/toprank-contentwriter.yaml
+++ b/website/src/content/skills/toprank-contentwriter.yaml
@@ -1,0 +1,28 @@
+name: "Toprank"
+slug: "toprank-contentwriter"
+type: "skill"
+
+author:
+  name: "nowork-studio"
+  github: "nowork-studio"
+
+description: >
+  给 Claude Code 直接接上 Google Search Console 和 Google Ads 的 SEO + Google Ads 技能。
+  分析流量、找出影响排名的问题、识别浪费的广告预算，并在有仓库权限时直接改 meta、修标题、加结构化数据。
+
+description_en: >
+  SEO + Google Ads skills for Claude Code with direct access to Google Search Console
+  and Google Ads. Analyzes traffic, surfaces ranking issues, finds wasted ad spend,
+  and — when given repo access — rewrites meta tags, fixes headings, and ships
+  structured-data changes.
+
+tags:
+  - other
+
+personality:
+  - 数据驱动
+  - 可执行
+  - 直接落地
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/nowork-studio/toprank"

--- a/website/src/content/skills/vibeportrait.yaml
+++ b/website/src/content/skills/vibeportrait.yaml
@@ -1,0 +1,24 @@
+name: "VibePortrait"
+slug: "vibeportrait"
+type: "meta-skill"
+
+author:
+  name: "dadwadw233"
+  github: "dadwadw233"
+
+description: >
+  读取你在 Claude Code / Codex 的对话历史，生成一张可视化的"开发者画像"：
+  MBTI 色卡、六维能力雷达、开发者评级、名人匹配、技术栈地图、工作节奏热力图。
+  同时产出一个"像你一样思考"的 Persona Skill，并通过 private GitHub 仓库跨机器同步。
+
+description_en: >
+  Reads your Claude Code / Codex conversation history and generates a visual
+  developer portrait — MBTI color theme, 6-axis capability radar, developer rating,
+  famous-person match, tech domain map, work rhythm heatmap — plus a "think like me"
+  persona skill, synced across machines via a private GitHub repo.
+
+tags:
+  - other
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/dadwadw233/VibePortrait"

--- a/website/src/content/skills/zhangxuefeng-skill.yaml
+++ b/website/src/content/skills/zhangxuefeng-skill.yaml
@@ -1,0 +1,26 @@
+name: "张雪峰.skill"
+slug: "zhangxuefeng-skill"
+type: "skill"
+
+author:
+  name: "alchaincyf"
+  github: "alchaincyf"
+
+description: >
+  蒸馏张雪峰的升学规划认知操作系统，基于 5 本著作、15+ 篇深度采访和 30+ 条一手语录，
+  提炼 5 个心智模型与 8 条决策启发式，用就业倒推、家庭背景分流和社会筛子论分析志愿填报。
+
+description_en: >
+  Distills Zhang Xuefeng's education-planning operating system from 5 books and 15+ media
+  interviews into mental models like employment reverse-engineering and family-resource triage.
+
+tags:
+  - other
+
+personality:
+  - 就业倒推
+  - 普通家庭视角
+  - 强结论表达
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/alchaincyf/zhangxuefeng-skill"

--- a/website/src/content/skills/zizek-skill.yaml
+++ b/website/src/content/skills/zizek-skill.yaml
@@ -1,0 +1,26 @@
+name: "zizek-skill"
+slug: "zizek-skill"
+type: "skill"
+
+author:
+  name: "JikunR"
+  github: "JikunR"
+
+description: >
+  用齐泽克式的问题意识做分析——追问前提、追踪欲望、识别功能、揭示矛盾，
+  把你自以为想清楚的东西翻出默认的那一层。不是齐泽克 cosplay，是分析工具。
+
+description_en: >
+  A Zizek-style analytical Skill that questions premises, traces desire, identifies function,
+  and surfaces contradictions rather than doing philosopher cosplay.
+
+tags:
+  - other
+
+personality:
+  - 追问前提
+  - 意识形态拆解
+  - 功能分析
+
+created_at: "2026-04-20"
+skill_repo: "https://github.com/JikunR/zizek-skill"


### PR DESCRIPTION
## Summary
- Bulk import of 34 community skills surfaced via two upstream awesome lists that weren't yet on the gallery
- Sources: [awesome-persona-distill-skills (xixu-me)](https://github.com/xixu-me/awesome-persona-distill-skills) and [awesome-persona-skills (tmstack)](https://github.com/tmstack/awesome-persona-skills)
- Excludes `wwwaapplleecu/mao-skill` per maintainer request

## Notes
- Slug collisions resolved via disambiguation: `boss-skills`, `ex-skill-xiaomanchu`, `fengge-skill`, `hu-chenfeng-skill`
- Each YAML follows the karpathy-skill schema (bilingual description, tags, `created_at: 2026-04-20`, `skill_repo`)
- `type` (skill vs meta-skill) inferred from each repo's README

## Test plan
- [ ] `npm run build` passes locally
- [ ] Spot-check a few cards render correctly on the gallery
- [ ] Verify GitHub links resolve